### PR TITLE
Move test suite into tests/ package

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+"""Test package. Ensures the project root is importable so test modules can
+`import proxy_server` under both `unittest discover` and pytest.
+"""
+
+import os
+import sys
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Test bootstrap: put the project root on sys.path so `import proxy_server`
+resolves regardless of the working directory the tests run from.
+
+Loaded automatically by both `unittest discover` (as a module in the tests
+package dir) and pytest (as a conftest plugin).
+"""
+
+import os
+import sys
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)

--- a/tests/test_load_balancer.py
+++ b/tests/test_load_balancer.py
@@ -1,0 +1,107 @@
+"""Characterization tests for load_balance_url round-robin + error paths.
+
+This is the exact function whose module-level counters will be made
+thread-safe in the optimization phase, so we lock in its observable
+behavior (selection sequence + raised errors) first.
+
+Note: load_balance_url stores its counters on the function object
+(load_balance_url.counters). We reset that in setUp so each test starts
+from a known counter state.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+import proxy_server
+from proxy_server import (
+    load_balance_url,
+    ProxyConfig,
+    SubAccountConfig,
+    ServiceKey,
+)
+
+
+def _make_config():
+    """Two subaccounts share 'shared-model'; sub-b also has a 2-URL model."""
+    sub_a = SubAccountConfig(
+        name="A",
+        resource_group="rg-a",
+        service_key_json="unused.json",
+        deployment_models={"shared-model": ["https://a/deploy1"]},
+    )
+    sub_a.service_key = ServiceKey("id", "secret", "https://auth", "zone")
+    sub_a.normalized_models = {"shared-model": ["https://a/deploy1"]}
+
+    sub_b = SubAccountConfig(
+        name="B",
+        resource_group="rg-b",
+        service_key_json="unused.json",
+        deployment_models={
+            "shared-model": ["https://b/deploy1"],
+            "multi-url": ["https://b/u1", "https://b/u2"],
+        },
+    )
+    sub_b.service_key = ServiceKey("id", "secret", "https://auth", "zone")
+    sub_b.normalized_models = {
+        "shared-model": ["https://b/deploy1"],
+        "multi-url": ["https://b/u1", "https://b/u2"],
+    }
+
+    cfg = ProxyConfig(
+        subaccounts={"A": sub_a, "B": sub_b},
+        secret_authentication_tokens=["tok"],
+    )
+    cfg.build_model_mapping()
+    return cfg
+
+
+class TestLoadBalanceUrl(unittest.TestCase):
+    def setUp(self):
+        # Fresh counters for every test (function attribute persists globally).
+        load_balance_url.counters = {}
+        self._cfg = _make_config()
+        self._patch = patch.object(proxy_server, "proxy_config", self._cfg)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        load_balance_url.counters = {}
+
+    def test_round_robin_across_subaccounts(self):
+        # 'shared-model' is on A and B; consecutive calls alternate subaccounts.
+        seen = [load_balance_url("shared-model")[1] for _ in range(4)]
+        # model mapping order is insertion order: A then B
+        self.assertEqual(seen, ["A", "B", "A", "B"])
+
+    def test_returns_expected_tuple_shape(self):
+        url, sub, rg, model = load_balance_url("shared-model")
+        self.assertEqual(model, "shared-model")
+        self.assertIn(sub, {"A", "B"})
+        self.assertTrue(url.startswith("https://"))
+        self.assertIn(rg, {"rg-a", "rg-b"})
+
+    def test_round_robin_across_urls_within_subaccount(self):
+        # 'multi-url' lives only on B with two URLs -> cycles between them.
+        urls = [load_balance_url("multi-url")[0] for _ in range(4)]
+        self.assertEqual(
+            urls,
+            ["https://b/u1", "https://b/u2", "https://b/u1", "https://b/u2"],
+        )
+
+    def test_unknown_model_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            load_balance_url("does-not-exist")
+
+    def test_model_with_empty_url_list_raises(self):
+        # Model registered in mapping but subaccount has empty URL list.
+        self._cfg.subaccounts["A"].normalized_models["shared-model"] = []
+        # Force selection of subaccount A (counter 0 -> index 0 -> A).
+        load_balance_url.counters = {}
+        with self.assertRaises(ValueError):
+            load_balance_url("shared-model")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_predicates.py
+++ b/tests/test_model_predicates.py
@@ -1,0 +1,72 @@
+"""Characterization tests for the model-routing predicates.
+
+These pin the CURRENT behavior of is_claude_model / is_claude_37_or_4 /
+is_gemini_model exactly as it is today, so the planned optimizations
+(which include tightening these predicates) can be verified not to change
+behavior silently. Cases marked "# QUIRK" capture arguably-wrong behavior
+that the optimization phase is expected to fix — when it does, flip that
+specific assertion in the same commit.
+"""
+
+import unittest
+
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+from proxy_server import is_claude_model, is_claude_37_or_4, is_gemini_model
+
+
+class TestIsClaudeModel(unittest.TestCase):
+    def test_matches_claude_names(self):
+        self.assertTrue(is_claude_model("anthropic--claude-4.6-opus"))
+        self.assertTrue(is_claude_model("claude-3.5-sonnet"))
+        self.assertTrue(is_claude_model("anthropic--claude-3.7-sonnet"))
+
+    def test_matches_sonnet_names(self):
+        self.assertTrue(is_claude_model("some-sonnet-model"))
+
+    def test_matches_uppercase(self):
+        self.assertTrue(is_claude_model("CLAUDE-X"))
+        self.assertTrue(is_claude_model("SONNET-X"))
+
+    def test_non_claude_models(self):
+        self.assertFalse(is_claude_model("gpt-5.4"))
+        self.assertFalse(is_claude_model("gpt-4o"))
+        self.assertFalse(is_claude_model("gemini-2.5-pro"))
+
+
+class TestIsClaude37Or4(unittest.TestCase):
+    def test_real_claude_37_and_4(self):
+        self.assertTrue(is_claude_37_or_4("anthropic--claude-4.6-opus"))
+        self.assertTrue(is_claude_37_or_4("anthropic--claude-3.7-sonnet"))
+        self.assertTrue(is_claude_37_or_4("anthropic--claude-4-sonnet"))
+
+    def test_claude_35_is_false(self):
+        self.assertFalse(is_claude_37_or_4("anthropic--claude-3.5-sonnet"))
+        self.assertFalse(is_claude_37_or_4("claude-3.5"))
+
+    def test_quirk_non_claude_names_return_true(self):
+        # QUIRK: the `or "3.5" not in model` clause makes ANY string without
+        # "3.5" return True — including non-Claude models and empty string.
+        # Optimization phase should replace this with an explicit Claude check.
+        self.assertTrue(is_claude_37_or_4("gpt-5.4"))       # QUIRK
+        self.assertTrue(is_claude_37_or_4(""))               # QUIRK
+        self.assertTrue(is_claude_37_or_4("gemini-2.5-pro")) # QUIRK
+
+    def test_substring_4_triggers_true(self):
+        # "4" appears in the string -> True regardless of "3.5" presence.
+        self.assertTrue(is_claude_37_or_4("claude-3.5-v4"))
+
+
+class TestIsGeminiModel(unittest.TestCase):
+    def test_matches_gemini(self):
+        self.assertTrue(is_gemini_model("gemini-2.5-pro"))
+        self.assertTrue(is_gemini_model("gemini-1.5-flash"))
+        self.assertTrue(is_gemini_model("GEMINI-PRO"))  # lower() applied internally
+
+    def test_non_gemini(self):
+        self.assertFalse(is_gemini_model("gpt-5.4"))
+        self.assertFalse(is_gemini_model("anthropic--claude-4.6-opus"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_request_converters.py
+++ b/tests/test_request_converters.py
@@ -1,0 +1,214 @@
+"""Characterization tests for request-format converters (client -> backend).
+
+Covers convert_openai_to_claude, convert_openai_to_claude37,
+convert_claude_request_to_openai, convert_claude_request_to_gemini.
+Behavior is pinned as-is; "# QUIRK" marks cases the optimization phase
+may revisit.
+"""
+
+import unittest
+
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+from proxy_server import (
+    convert_openai_to_claude,
+    convert_openai_to_claude37,
+    convert_claude_request_to_openai,
+    convert_claude_request_to_gemini,
+)
+
+
+class TestConvertOpenAIToClaude(unittest.TestCase):
+    def test_extracts_leading_system_message(self):
+        payload = {
+            "messages": [
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": "hi"},
+            ]
+        }
+        out = convert_openai_to_claude(payload)
+        self.assertEqual(out["system"], "be terse")
+        self.assertEqual(out["messages"], [{"role": "user", "content": "hi"}])
+        self.assertEqual(out["anthropic_version"], "bedrock-2023-05-31")
+
+    def test_defaults_applied(self):
+        payload = {"messages": [{"role": "user", "content": "hi"}]}
+        out = convert_openai_to_claude(payload)
+        self.assertEqual(out["system"], "")
+        self.assertEqual(out["max_tokens"], 4096000)  # QUIRK: very large default
+        self.assertEqual(out["temperature"], 1.0)
+
+    def test_respects_provided_values(self):
+        payload = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "temperature": 0.2,
+        }
+        out = convert_openai_to_claude(payload)
+        self.assertEqual(out["max_tokens"], 100)
+        self.assertEqual(out["temperature"], 0.2)
+
+
+class TestConvertOpenAIToClaude37(unittest.TestCase):
+    def test_string_content_becomes_text_block(self):
+        payload = {"messages": [{"role": "user", "content": "hello"}]}
+        out = convert_openai_to_claude37(payload)
+        self.assertEqual(
+            out["messages"], [{"role": "user", "content": [{"text": "hello"}]}]
+        )
+
+    def test_inference_config_mapping(self):
+        payload = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 256,
+            "temperature": 0.5,
+            "stop": "STOP",
+        }
+        out = convert_openai_to_claude37(payload)
+        cfg = out["inferenceConfig"]
+        self.assertEqual(cfg["maxTokens"], 256)
+        self.assertEqual(cfg["temperature"], 0.5)
+        self.assertEqual(cfg["stopSequences"], ["STOP"])  # str -> list
+
+    def test_stop_list_passthrough(self):
+        payload = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "stop": ["a", "b"],
+        }
+        out = convert_openai_to_claude37(payload)
+        self.assertEqual(out["inferenceConfig"]["stopSequences"], ["a", "b"])
+
+    def test_system_message_inserted_as_first_user_block(self):
+        payload = {
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hi"},
+            ]
+        }
+        out = convert_openai_to_claude37(payload)
+        self.assertEqual(out["messages"][0], {"role": "user", "content": [{"text": "sys"}]})
+        self.assertEqual(out["messages"][1], {"role": "user", "content": [{"text": "hi"}]})
+
+    def test_image_url_data_url_to_bedrock_converse(self):
+        b64 = "aGVsbG8="
+        payload = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}},
+                    ],
+                }
+            ]
+        }
+        out = convert_openai_to_claude37(payload)
+        block = out["messages"][0]["content"][0]
+        self.assertEqual(block["image"]["format"], "png")
+        self.assertEqual(block["image"]["source"]["bytes"], b64)
+
+    def test_unsupported_role_skipped(self):
+        payload = {
+            "messages": [
+                {"role": "tool", "content": "ignored"},
+                {"role": "user", "content": "kept"},
+            ]
+        }
+        out = convert_openai_to_claude37(payload)
+        # Only the user message survives.
+        self.assertEqual(len(out["messages"]), 1)
+        self.assertEqual(out["messages"][0]["role"], "user")
+
+    def test_no_inference_config_when_empty(self):
+        payload = {"messages": [{"role": "user", "content": "hi"}]}
+        out = convert_openai_to_claude37(payload)
+        self.assertNotIn("inferenceConfig", out)
+
+
+class TestConvertClaudeRequestToOpenAI(unittest.TestCase):
+    def test_system_and_token_mapping(self):
+        payload = {
+            "model": "claude-x",
+            "system": "sys",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 50,
+            "temperature": 0.3,
+            "stream": True,
+        }
+        out = convert_claude_request_to_openai(payload)
+        self.assertEqual(out["messages"][0], {"role": "system", "content": "sys"})
+        self.assertEqual(out["messages"][1], {"role": "user", "content": "hi"})
+        self.assertEqual(out["max_completion_tokens"], 50)
+        self.assertEqual(out["temperature"], 0.3)
+        self.assertTrue(out["stream"])
+        self.assertEqual(out["model"], "claude-x")
+
+    def test_tools_mapped_to_function_format(self):
+        payload = {
+            "model": "claude-x",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {"name": "t", "description": "d", "input_schema": {"type": "object"}}
+            ],
+        }
+        out = convert_claude_request_to_openai(payload)
+        tool = out["tools"][0]
+        self.assertEqual(tool["type"], "function")
+        self.assertEqual(tool["function"]["name"], "t")
+        self.assertEqual(tool["function"]["parameters"], {"type": "object"})
+
+    def test_no_system_when_absent(self):
+        payload = {"model": "claude-x", "messages": [{"role": "user", "content": "hi"}]}
+        out = convert_claude_request_to_openai(payload)
+        self.assertEqual(out["messages"][0]["role"], "user")
+
+
+class TestConvertClaudeRequestToGemini(unittest.TestCase):
+    def test_system_prepended_to_first_user(self):
+        payload = {
+            "system": "SYS",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        out = convert_claude_request_to_gemini(payload)
+        text = out["contents"][0]["parts"]["text"]
+        self.assertIn("SYS", text)
+        self.assertIn("hi", text)
+
+    def test_role_mapping_and_merge(self):
+        payload = {
+            "messages": [
+                {"role": "assistant", "content": "a1"},
+                {"role": "assistant", "content": "a2"},
+                {"role": "user", "content": "u1"},
+            ]
+        }
+        out = convert_claude_request_to_gemini(payload)
+        # Two consecutive assistant messages merge into one 'model' entry.
+        self.assertEqual(out["contents"][0]["role"], "model")
+        self.assertIn("a1", out["contents"][0]["parts"]["text"])
+        self.assertIn("a2", out["contents"][0]["parts"]["text"])
+        self.assertEqual(out["contents"][1]["role"], "user")
+
+    def test_list_content_text_join(self):
+        payload = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "x"}, {"type": "text", "text": "y"}]}
+            ]
+        }
+        out = convert_claude_request_to_gemini(payload)
+        self.assertEqual(out["contents"][0]["parts"]["text"], "x y")
+
+    def test_generation_config_and_tools(self):
+        payload = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 42,
+            "temperature": 0.7,
+            "tools": [{"name": "t", "description": "d", "input_schema": {"type": "object"}}],
+        }
+        out = convert_claude_request_to_gemini(payload)
+        self.assertEqual(out["generation_config"]["maxOutputTokens"], 42)
+        self.assertEqual(out["generation_config"]["temperature"], 0.7)
+        self.assertEqual(out["tools"][0]["function_declarations"][0]["name"], "t")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_response_converters.py
+++ b/tests/test_response_converters.py
@@ -1,0 +1,201 @@
+"""Characterization tests for response-format converters (backend -> client).
+
+Covers convert_claude_to_openai, convert_claude37_to_openai,
+convert_gemini_to_openai, convert_gemini_response_to_claude,
+convert_openai_response_to_claude. IDs use random/time; assertions target
+stable fields only.
+"""
+
+import unittest
+
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+from proxy_server import (
+    convert_claude_to_openai,
+    convert_claude37_to_openai,
+    convert_gemini_to_openai,
+    convert_gemini_response_to_claude,
+    convert_openai_response_to_claude,
+)
+
+
+class TestConvertClaudeToOpenAI(unittest.TestCase):
+    def test_standard_claude_path(self):
+        # A non-3.7/4 model name (contains "3.5") uses the standard branch.
+        response = {
+            "content": [{"text": "hello"}],
+            "stop_reason": "end_turn",
+            "role": "assistant",
+            "id": "abc",
+            "model": "claude-3.5",
+            "usage": {"input_tokens": 3, "output_tokens": 5},
+        }
+        out = convert_claude_to_openai(response, "anthropic--claude-3.5-sonnet")
+        self.assertEqual(out["choices"][0]["message"]["content"], "hello")
+        self.assertEqual(out["choices"][0]["finish_reason"], "end_turn")
+        self.assertEqual(out["usage"]["prompt_tokens"], 3)
+        self.assertEqual(out["usage"]["completion_tokens"], 5)
+        self.assertEqual(out["usage"]["total_tokens"], 8)
+
+    def test_delegates_to_claude37_for_4x(self):
+        # A 4.x model routes through the /converse converter, which expects
+        # the output.message.content shape.
+        response = {
+            "output": {"message": {"role": "assistant", "content": [{"text": "hi"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 1, "outputTokens": 2, "totalTokens": 3},
+        }
+        out = convert_claude_to_openai(response, "anthropic--claude-4.6-opus")
+        self.assertEqual(out["choices"][0]["message"]["content"], "hi")
+        self.assertEqual(out["usage"]["total_tokens"], 3)
+
+    def test_malformed_returns_error_struct(self):
+        out = convert_claude_to_openai({"bad": "shape"}, "anthropic--claude-3.5-sonnet")
+        self.assertIn("error", out)
+
+
+class TestConvertClaude37ToOpenAI(unittest.TestCase):
+    def _resp(self, **over):
+        base = {
+            "output": {"message": {"role": "assistant", "content": [{"text": "hi"}]}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 10, "outputTokens": 20, "totalTokens": 30},
+        }
+        base.update(over)
+        return base
+
+    def test_basic_extraction(self):
+        out = convert_claude37_to_openai(self._resp(), "m")
+        self.assertEqual(out["choices"][0]["message"]["content"], "hi")
+        self.assertEqual(out["choices"][0]["finish_reason"], "stop")
+        self.assertEqual(out["model"], "m")
+        self.assertEqual(out["usage"]["total_tokens"], 30)
+
+    def test_stop_reason_map(self):
+        self.assertEqual(
+            convert_claude37_to_openai(self._resp(stopReason="max_tokens"), "m")["choices"][0]["finish_reason"],
+            "length",
+        )
+        self.assertEqual(
+            convert_claude37_to_openai(self._resp(stopReason="tool_use"), "m")["choices"][0]["finish_reason"],
+            "tool_calls",
+        )
+        self.assertEqual(
+            convert_claude37_to_openai(self._resp(stopReason="unknown_xyz"), "m")["choices"][0]["finish_reason"],
+            "stop",  # default
+        )
+
+    def test_first_text_block_fallback(self):
+        # Block 0 is not text; converter scans for the first text block.
+        resp = self._resp()
+        resp["output"]["message"]["content"] = [
+            {"type": "tool_use", "id": "x"},
+            {"type": "text", "text": "found"},
+        ]
+        out = convert_claude37_to_openai(resp, "m")
+        self.assertEqual(out["choices"][0]["message"]["content"], "found")
+
+    def test_total_tokens_fallback_when_missing(self):
+        resp = self._resp(usage={"inputTokens": 4, "outputTokens": 6})
+        out = convert_claude37_to_openai(resp, "m")
+        self.assertEqual(out["usage"]["total_tokens"], 10)
+
+    def test_malformed_returns_error_object(self):
+        out = convert_claude37_to_openai({"bad": True}, "m")
+        self.assertEqual(out["object"], "error")
+        self.assertEqual(out["type"], "proxy_conversion_error")
+
+
+class TestConvertGeminiToOpenAI(unittest.TestCase):
+    def _resp(self, **over):
+        base = {
+            "candidates": [
+                {"content": {"parts": [{"text": "hi"}]}, "finishReason": "STOP"}
+            ],
+            "usageMetadata": {"promptTokenCount": 2, "candidatesTokenCount": 3, "totalTokenCount": 5},
+        }
+        base.update(over)
+        return base
+
+    def test_basic(self):
+        out = convert_gemini_to_openai(self._resp(), "gemini-2.5-pro")
+        self.assertEqual(out["choices"][0]["message"]["content"], "hi")
+        self.assertEqual(out["choices"][0]["finish_reason"], "stop")
+        self.assertEqual(out["usage"]["total_tokens"], 5)
+        self.assertEqual(out["model"], "gemini-2.5-pro")
+
+    def test_safety_finish_reason_maps_to_content_filter(self):
+        resp = self._resp()
+        resp["candidates"][0]["finishReason"] = "SAFETY"
+        out = convert_gemini_to_openai(resp, "m")
+        self.assertEqual(out["choices"][0]["finish_reason"], "content_filter")
+
+    def test_no_candidates_returns_error(self):
+        out = convert_gemini_to_openai({"candidates": []}, "m")
+        self.assertEqual(out["object"], "error")
+
+
+class TestConvertGeminiResponseToClaude(unittest.TestCase):
+    def test_basic(self):
+        resp = {
+            "candidates": [{"content": {"parts": [{"text": "hi"}]}, "finishReason": "STOP"}],
+            "usageMetadata": {"promptTokenCount": 2, "candidatesTokenCount": 3},
+        }
+        out = convert_gemini_response_to_claude(resp, "gemini-2.5-pro")
+        self.assertEqual(out["type"], "message")
+        self.assertEqual(out["content"][0]["text"], "hi")
+        self.assertEqual(out["stop_reason"], "end_turn")
+        self.assertEqual(out["usage"]["input_tokens"], 2)
+
+    def test_error_struct(self):
+        out = convert_gemini_response_to_claude({"candidates": []}, "m")
+        self.assertEqual(out["type"], "error")
+
+
+class TestConvertOpenAIResponseToClaude(unittest.TestCase):
+    def test_text_content(self):
+        resp = {
+            "id": "cid",
+            "model": "gpt-5.4",
+            "choices": [{"message": {"content": "hello"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 2},
+        }
+        out = convert_openai_response_to_claude(resp)
+        self.assertEqual(out["content"][0], {"type": "text", "text": "hello"})
+        self.assertEqual(out["stop_reason"], "end_turn")
+        self.assertEqual(out["id"], "cid")
+        self.assertEqual(out["usage"]["input_tokens"], 1)
+
+    def test_tool_calls_converted(self):
+        resp = {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "id": "call_1",
+                                "function": {"name": "f", "arguments": '{"a": 1}'},
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {},
+        }
+        out = convert_openai_response_to_claude(resp)
+        tool_use = out["content"][0]
+        self.assertEqual(tool_use["type"], "tool_use")
+        self.assertEqual(tool_use["name"], "f")
+        self.assertEqual(tool_use["input"], {"a": 1})
+        self.assertEqual(out["stop_reason"], "tool_use")
+
+    def test_empty_choices_returns_error(self):
+        out = convert_openai_response_to_claude({"choices": []})
+        self.assertEqual(out["type"], "error")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -3,6 +3,8 @@ import json
 import time
 from unittest.mock import patch, MagicMock
 
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
 from proxy_server import (
     convert_responses_input_to_messages,
     convert_responses_tools,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,303 @@
+"""Characterization tests for the Flask route handlers.
+
+Uses app.test_client(). All upstream I/O is mocked:
+- proxy_config is replaced with a fake 3-model config (GPT/Claude/Gemini).
+- fetch_token is stubbed (no OAuth call).
+- _http_session.post is stubbed for GPT/embeddings paths.
+- get_sapaicore_sdk_client is stubbed for the Claude /v1/messages path.
+
+"# QUIRK" marks behavior the optimization phase may revisit (e.g. /v1/models
+performing no auth check).
+"""
+
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+import proxy_server
+from proxy_server import (
+    app,
+    ProxyConfig,
+    SubAccountConfig,
+    ServiceKey,
+    load_balance_url,
+)
+
+TOKEN = "test-secret-token"
+
+
+def _make_config():
+    sub = SubAccountConfig(
+        name="S",
+        resource_group="rg",
+        service_key_json="unused.json",
+        deployment_models={
+            "gpt-5.4": ["https://backend/gpt"],
+            "anthropic--claude-4.6-opus": ["https://backend/claude"],
+            "gemini-2.5-pro": ["https://backend/gemini"],
+        },
+    )
+    sub.service_key = ServiceKey("id", "secret", "https://auth", "zone")
+    sub.normalized_models = dict(sub.deployment_models)
+    cfg = ProxyConfig(
+        subaccounts={"S": sub},
+        secret_authentication_tokens=[TOKEN],
+        model_to_subaccounts={},
+    )
+    cfg.build_model_mapping()
+    return cfg
+
+
+def _fake_post(json_body, status=200):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = json_body
+    resp.status_code = status
+    resp.close.return_value = None
+    return resp
+
+
+class _RouteTestBase(unittest.TestCase):
+    def setUp(self):
+        load_balance_url.counters = {}
+        self.cfg = _make_config()
+        self._p = patch.object(proxy_server, "proxy_config", self.cfg)
+        self._p.start()
+        self.client = app.test_client()
+        self._ft = patch.object(proxy_server, "fetch_token", return_value="backend-tok")
+        self._ft.start()
+
+    def tearDown(self):
+        self._ft.stop()
+        self._p.stop()
+        load_balance_url.counters = {}
+
+    def _auth(self):
+        return {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+
+
+class TestHealthAndModels(_RouteTestBase):
+    def test_health_ok(self):
+        r = self.client.get("/health")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()["status"], "ok")
+
+    def test_models_lists_configured(self):
+        # QUIRK: /v1/models performs no token verification (auth check commented out).
+        r = self.client.get("/v1/models")
+        self.assertEqual(r.status_code, 200)
+        ids = {m["id"] for m in r.get_json()["data"]}
+        self.assertEqual(ids, {"gpt-5.4", "anthropic--claude-4.6-opus", "gemini-2.5-pro"})
+
+
+class TestAuth(_RouteTestBase):
+    def test_missing_token_401(self):
+        r = self.client.post("/v1/chat/completions", json={"model": "gpt-5.4", "messages": []})
+        self.assertEqual(r.status_code, 401)
+
+    def test_invalid_token_401(self):
+        r = self.client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer wrong"},
+            json={"model": "gpt-5.4", "messages": []},
+        )
+        self.assertEqual(r.status_code, 401)
+
+    def test_messages_missing_token_401(self):
+        r = self.client.post("/v1/messages", json={"model": "anthropic--claude-4.6-opus", "messages": []})
+        self.assertEqual(r.status_code, 401)
+
+    def test_auth_disabled_when_no_tokens_configured(self):
+        # Pin behavior: empty secret list => auth disabled (verify_request_token True).
+        self.cfg.secret_authentication_tokens = []
+        with patch.object(proxy_server, "_http_session") as sess:
+            sess.post.return_value = _fake_post({"usage": {}, "choices": []})
+            r = self.client.post(
+                "/v1/chat/completions",
+                headers={"Content-Type": "application/json"},
+                json={"model": "gpt-5.4", "messages": [{"role": "user", "content": "hi"}]},
+            )
+        self.assertEqual(r.status_code, 200)
+
+
+class TestChatCompletionsRouting(_RouteTestBase):
+    def test_gpt_non_streaming(self):
+        backend_json = {"choices": [{"message": {"content": "hi"}}], "usage": {"total_tokens": 3}}
+        with patch.object(proxy_server, "_http_session") as sess:
+            sess.post.return_value = _fake_post(backend_json)
+            r = self.client.post(
+                "/v1/chat/completions",
+                headers=self._auth(),
+                json={"model": "gpt-5.4", "messages": [{"role": "user", "content": "hi"}]},
+            )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()["choices"][0]["message"]["content"], "hi")
+
+    def test_unknown_model_falls_back_to_gpt(self):
+        backend_json = {"choices": [{"message": {"content": "x"}}], "usage": {}}
+        with patch.object(proxy_server, "_http_session") as sess:
+            sess.post.return_value = _fake_post(backend_json)
+            r = self.client.post(
+                "/v1/chat/completions",
+                headers=self._auth(),
+                json={"model": "no-such-model", "messages": [{"role": "user", "content": "hi"}]},
+            )
+        # Falls back to gpt-5.4 (present) -> 200.
+        self.assertEqual(r.status_code, 200)
+
+    def test_unknown_model_and_no_fallback_404(self):
+        # Remove gpt-5.4 so the fallback also fails.
+        del self.cfg.subaccounts["S"].normalized_models["gpt-5.4"]
+        self.cfg.build_model_mapping()
+        r = self.client.post(
+            "/v1/chat/completions",
+            headers=self._auth(),
+            json={"model": "no-such-model", "messages": []},
+        )
+        self.assertEqual(r.status_code, 404)
+
+
+class TestMessagesRoute(_RouteTestBase):
+    def _sdk_returning(self, body_dict):
+        """Fake SDK client whose invoke_model yields a JSON body of body_dict."""
+        client = MagicMock()
+        payload_bytes = json.dumps(body_dict).encode("utf-8")
+        client.invoke_model.return_value = {"body": [payload_bytes]}
+        return client
+
+    def test_claude_non_streaming_returns_body(self):
+        sdk = self._sdk_returning(
+            {"content": [{"type": "text", "text": "hi"}], "usage": {"input_tokens": 1, "output_tokens": 2}}
+        )
+        with patch.object(proxy_server, "get_sapaicore_sdk_client", return_value=sdk):
+            r = self.client.post(
+                "/v1/messages",
+                headers={"x-api-key": TOKEN, "Content-Type": "application/json"},
+                json={
+                    "model": "anthropic--claude-4.6-opus",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "max_tokens": 100,
+                    "stream": False,
+                },
+            )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()["content"][0]["text"], "hi")
+
+    def test_missing_model_400(self):
+        r = self.client.post(
+            "/v1/messages",
+            headers={"x-api-key": TOKEN, "Content-Type": "application/json"},
+            json={"messages": []},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_system_message_extracted_into_top_level(self):
+        # Capture the body passed to invoke_model and assert system extraction.
+        sdk = self._sdk_returning({"content": [{"type": "text", "text": "x"}], "usage": {}})
+        with patch.object(proxy_server, "get_sapaicore_sdk_client", return_value=sdk):
+            self.client.post(
+                "/v1/messages",
+                headers={"x-api-key": TOKEN, "Content-Type": "application/json"},
+                json={
+                    "model": "anthropic--claude-4.6-opus",
+                    "system": None,
+                    "messages": [
+                        {"role": "system", "content": "be nice"},
+                        {"role": "user", "content": "hi"},
+                    ],
+                    "max_tokens": 50,
+                    "stream": False,
+                },
+            )
+        sent = json.loads(sdk.invoke_model.call_args.kwargs["body"])
+        self.assertIn("system", sent)
+        self.assertEqual(sent["system"], [{"type": "text", "text": "be nice"}])
+        self.assertTrue(all(m["role"] != "system" for m in sent["messages"]))
+        self.assertEqual(sent["anthropic_version"], "bedrock-2023-05-31")
+
+    def test_context_management_and_output_config_removed(self):
+        sdk = self._sdk_returning({"content": [{"type": "text", "text": "x"}], "usage": {}})
+        with patch.object(proxy_server, "get_sapaicore_sdk_client", return_value=sdk):
+            self.client.post(
+                "/v1/messages",
+                headers={"x-api-key": TOKEN, "Content-Type": "application/json"},
+                json={
+                    "model": "anthropic--claude-4.6-opus",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "context_management": {"foo": 1},
+                    "output_config": {"bar": 2},
+                    "max_tokens": 50,
+                    "stream": False,
+                },
+            )
+        sent = json.loads(sdk.invoke_model.call_args.kwargs["body"])
+        self.assertNotIn("context_management", sent)
+        self.assertNotIn("output_config", sent)
+
+    def test_thinking_budget_adjusts_max_tokens(self):
+        sdk = self._sdk_returning({"content": [{"type": "text", "text": "x"}], "usage": {}})
+        with patch.object(proxy_server, "get_sapaicore_sdk_client", return_value=sdk):
+            self.client.post(
+                "/v1/messages",
+                headers={"x-api-key": TOKEN, "Content-Type": "application/json"},
+                json={
+                    "model": "anthropic--claude-4.6-opus",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "thinking": {"type": "enabled", "budget_tokens": 1000},
+                    "max_tokens": 500,  # below budget -> should be bumped to budget+1
+                    "stream": False,
+                },
+            )
+        sent = json.loads(sdk.invoke_model.call_args.kwargs["body"])
+        self.assertEqual(sent["max_tokens"], 1001)
+
+
+class TestEmbeddingsRoute(_RouteTestBase):
+    def test_requires_input(self):
+        r = self.client.post(
+            "/v1/embeddings",
+            headers=self._auth(),
+            json={"model": "gpt-5.4"},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_embedding_formatting(self):
+        # embeddings uses load_balance_url on the model; add an embedding model.
+        self.cfg.subaccounts["S"].normalized_models["text-embedding-3-large"] = ["https://backend/emb"]
+        self.cfg.build_model_mapping()
+        backend_json = {"data": [{"embedding": [0.1, 0.2], "index": 0}]}
+        with patch.object(proxy_server, "_http_session") as sess:
+            sess.post.return_value = _fake_post(backend_json)
+            r = self.client.post(
+                "/v1/embeddings",
+                headers=self._auth(),
+                json={"model": "text-embedding-3-large", "input": "hello"},
+            )
+        self.assertEqual(r.status_code, 200)
+        body = r.get_json()
+        self.assertEqual(body["object"], "list")
+        self.assertEqual(body["data"][0]["embedding"], [0.1, 0.2])
+        self.assertEqual(body["usage"]["total_tokens"], 2)
+
+
+class TestResponsesRoute(_RouteTestBase):
+    def test_non_streaming_string_input(self):
+        backend_json = {
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+        }
+        with patch.object(proxy_server, "_http_session") as sess:
+            sess.post.return_value = _fake_post(backend_json)
+            r = self.client.post(
+                "/v1/responses",
+                headers=self._auth(),
+                json={"model": "gpt-5.4", "input": "hi", "stream": False},
+            )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()["object"], "response")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sanitize_bedrock_tools.py
+++ b/tests/test_sanitize_bedrock_tools.py
@@ -1,0 +1,97 @@
+import unittest
+
+
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+from proxy_server import sanitize_bedrock_tools
+from proxy_server import sanitize_bedrock_tool_result_content
+
+
+class TestSanitizeBedrockTools(unittest.TestCase):
+    def test_removes_custom_defer_loading(self):
+        body = {
+            "tools": [
+                {
+                    "name": "t1",
+                    "description": "d",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "custom": {"defer_loading": True},
+                }
+            ]
+        }
+
+        sanitize_bedrock_tools(body, request_id="test")
+
+        self.assertIn("tools", body)
+        self.assertEqual(1, len(body["tools"]))
+        self.assertNotIn("custom", body["tools"][0])
+
+    def test_strips_unsupported_tool_types_and_tool_choice(self):
+        body = {
+            "tools": [
+                {"type": "web_search_20250305", "name": "search"},
+                {"type": "computer_20241022", "name": "computer"},
+            ],
+            "tool_choice": {"type": "auto"},
+        }
+
+        sanitize_bedrock_tools(body, request_id="test")
+
+        self.assertNotIn("tools", body)
+        self.assertNotIn("tool_choice", body)
+
+
+class TestSanitizeBedrockToolResultContent(unittest.TestCase):
+    def test_converts_tool_reference_block_to_text(self):
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "1",
+                            "content": [
+                                {"type": "tool_reference", "tool_name": "Read"},
+                                {"type": "text", "text": "ok"},
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        sanitize_bedrock_tool_result_content(body, request_id="test")
+
+        tool_result = body["messages"][0]["content"][0]
+        self.assertEqual("tool_result", tool_result["type"])
+        self.assertIsInstance(tool_result["content"], list)
+        self.assertEqual("text", tool_result["content"][0]["type"])
+        self.assertIn("tool_ref", tool_result["content"][0]["text"])
+        self.assertEqual("text", tool_result["content"][1]["type"])
+        self.assertEqual("ok", tool_result["content"][1]["text"])
+
+    def test_normalizes_string_tool_result_content_to_list(self):
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "1",
+                            "content": "hello",
+                        }
+                    ],
+                }
+            ]
+        }
+
+        sanitize_bedrock_tool_result_content(body, request_id="test")
+
+        tool_result = body["messages"][0]["content"][0]
+        self.assertEqual([{"type": "text", "text": "hello"}], tool_result["content"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sanitize_extra.py
+++ b/tests/test_sanitize_extra.py
@@ -1,0 +1,144 @@
+"""Extra branch coverage for the Bedrock sanitizers.
+
+test_sanitize_bedrock_tools.py already covers the happy paths; this file
+pins the remaining edge branches (invalid inputs, count return values,
+passthrough) so the sanitizers can be refactored safely.
+"""
+
+import unittest
+
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+from proxy_server import sanitize_bedrock_tools, sanitize_bedrock_tool_result_content
+
+
+class TestSanitizeBedrockToolsEdges(unittest.TestCase):
+    def test_non_list_tools_is_noop(self):
+        body = {"tools": "not-a-list"}
+        result = sanitize_bedrock_tools(body)
+        self.assertEqual(result, {"removed_fields": 0, "stripped_tools": 0})
+        self.assertEqual(body["tools"], "not-a-list")  # untouched
+
+    def test_missing_tools_key_is_noop(self):
+        body = {}
+        result = sanitize_bedrock_tools(body)
+        self.assertEqual(result["stripped_tools"], 0)
+
+    def test_non_dict_tool_is_stripped(self):
+        body = {"tools": ["oops", 123]}
+        sanitize_bedrock_tools(body)
+        self.assertNotIn("tools", body)  # all stripped -> key removed
+
+    def test_missing_or_empty_name_stripped(self):
+        body = {
+            "tools": [
+                {"description": "d", "input_schema": {"type": "object"}},  # no name
+                {"name": "", "description": "d", "input_schema": {"type": "object"}},  # empty
+            ]
+        }
+        sanitize_bedrock_tools(body)
+        self.assertNotIn("tools", body)
+
+    def test_non_dict_input_schema_stripped(self):
+        body = {"tools": [{"name": "t", "description": "d", "input_schema": "bad"}]}
+        sanitize_bedrock_tools(body)
+        self.assertNotIn("tools", body)
+
+    def test_non_str_description_coerced_to_empty(self):
+        body = {"tools": [{"name": "t", "description": 123, "input_schema": {"type": "object"}}]}
+        sanitize_bedrock_tools(body)
+        self.assertEqual(body["tools"][0]["description"], "")
+
+    def test_removed_fields_counted(self):
+        body = {
+            "tools": [
+                {
+                    "name": "t",
+                    "description": "d",
+                    "input_schema": {"type": "object"},
+                    "extra1": 1,
+                    "extra2": 2,
+                }
+            ]
+        }
+        result = sanitize_bedrock_tools(body)
+        self.assertEqual(result["removed_fields"], 2)
+        self.assertEqual(set(body["tools"][0].keys()), {"name", "description", "input_schema"})
+
+    def test_valid_tool_preserved(self):
+        body = {"tools": [{"name": "t", "description": "d", "input_schema": {"type": "object"}}]}
+        sanitize_bedrock_tools(body)
+        self.assertEqual(len(body["tools"]), 1)
+
+
+class TestSanitizeToolResultContentEdges(unittest.TestCase):
+    def test_dict_content_dumped_to_text(self):
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "1", "content": {"k": "v"}}
+                    ],
+                }
+            ]
+        }
+        result = sanitize_bedrock_tool_result_content(body)
+        block = body["messages"][0]["content"][0]["content"][0]
+        self.assertEqual(block["type"], "text")
+        self.assertIn("k", block["text"])
+        self.assertEqual(result["normalized_tool_results"], 1)
+
+    def test_allowed_content_types_passthrough(self):
+        original = [{"type": "text", "text": "keep"}, {"type": "image", "source": {}}]
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "1", "content": list(original)}
+                    ],
+                }
+            ]
+        }
+        sanitize_bedrock_tool_result_content(body)
+        self.assertEqual(body["messages"][0]["content"][0]["content"], original)
+
+    def test_unsupported_block_converted(self):
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "1",
+                            "content": [{"type": "weird_block", "x": 1}],
+                        }
+                    ],
+                }
+            ]
+        }
+        result = sanitize_bedrock_tool_result_content(body)
+        block = body["messages"][0]["content"][0]["content"][0]
+        self.assertEqual(block["type"], "text")
+        self.assertIn("[unsupported_tool_result_content]", block["text"])
+        self.assertEqual(result["converted_blocks"], 1)
+
+    def test_non_list_messages_noop(self):
+        body = {"messages": "nope"}
+        result = sanitize_bedrock_tool_result_content(body)
+        self.assertEqual(result, {"converted_blocks": 0, "normalized_tool_results": 0})
+
+    def test_non_tool_result_untouched(self):
+        body = {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+            ]
+        }
+        sanitize_bedrock_tool_result_content(body)
+        self.assertEqual(body["messages"][0]["content"][0], {"type": "text", "text": "hi"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,202 @@
+"""Characterization tests for streaming: chunk converters + generators.
+
+Chunk converters are pure and cheap. The generator functions
+(generate_streaming_response, generate_claude_streaming_response) read the
+Flask `request` object and call `_http_session.post(...)`, so they run inside
+an `app.test_request_context` with `_http_session.post` mocked to return a
+fake streaming response. No real network I/O occurs.
+"""
+
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+
+import os as _os, sys as _sys
+_sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__))))
+import proxy_server
+from proxy_server import (
+    app,
+    convert_claude_chunk_to_openai,
+    convert_claude37_chunk_to_openai,
+    convert_gemini_chunk_to_openai,
+    convert_gemini_chunk_to_claude_delta,
+    get_claude_stop_reason_from_gemini_chunk,
+    convert_openai_chunk_to_claude_delta,
+    get_claude_stop_reason_from_openai_chunk,
+    generate_streaming_response,
+)
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+class _FakeStreamResponse:
+    """Mimics the context-manager streaming response from requests."""
+
+    def __init__(self, lines=None, content_chunks=None, status=200):
+        self._lines = lines or []
+        self._content_chunks = content_chunks or []
+        self.status_code = status
+        self.headers = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_lines(self):
+        for ln in self._lines:
+            yield ln if isinstance(ln, bytes) else ln.encode("utf-8")
+
+    def iter_content(self, chunk_size=128):
+        for c in self._content_chunks:
+            yield c if isinstance(c, bytes) else c.encode("utf-8")
+
+
+def _drain(gen):
+    """Collect a generator's output as a list of str (decoding bytes)."""
+    out = []
+    for item in gen:
+        out.append(item.decode("utf-8") if isinstance(item, bytes) else item)
+    return out
+
+
+# --------------------------------------------------------------------------
+# Chunk converters (pure)
+# --------------------------------------------------------------------------
+class TestConvertClaudeChunkToOpenAI(unittest.TestCase):
+    def test_content_block_delta(self):
+        chunk = 'data: {"type": "content_block_delta", "delta": {"text": "hi"}}'
+        out = convert_claude_chunk_to_openai(chunk, "claude-3.5")
+        self.assertTrue(out.startswith("data: "))
+        payload = json.loads(out[len("data: "):].strip())
+        self.assertEqual(payload["choices"][0]["delta"]["content"], "hi")
+
+    def test_message_delta_end_turn_sets_finish(self):
+        chunk = 'data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}}'
+        payload = json.loads(convert_claude_chunk_to_openai(chunk, "claude-3.5")[6:].strip())
+        self.assertEqual(payload["choices"][0]["finish_reason"], "stop")
+
+    def test_invalid_json_returns_error_sse(self):
+        out = convert_claude_chunk_to_openai("data: not-json", "claude-3.5")
+        self.assertIn("error", out)
+
+
+class TestConvertClaude37ChunkToOpenAI(unittest.TestCase):
+    def test_content_block_delta(self):
+        out = convert_claude37_chunk_to_openai(
+            {"contentBlockDelta": {"delta": {"text": "hi"}}}, "m"
+        )
+        payload = json.loads(out[6:].strip())
+        self.assertEqual(payload["choices"][0]["delta"]["content"], "hi")
+
+    def test_message_start_role(self):
+        out = convert_claude37_chunk_to_openai({"messageStart": {"role": "assistant"}}, "m")
+        payload = json.loads(out[6:].strip())
+        self.assertEqual(payload["choices"][0]["delta"]["role"], "assistant")
+
+    def test_message_stop_maps_finish_reason(self):
+        out = convert_claude37_chunk_to_openai({"messageStop": {"stopReason": "max_tokens"}}, "m")
+        payload = json.loads(out[6:].strip())
+        self.assertEqual(payload["choices"][0]["finish_reason"], "length")
+
+    def test_metadata_chunk_returns_none(self):
+        self.assertIsNone(convert_claude37_chunk_to_openai({"metadata": {}}, "m"))
+
+    def test_content_block_delta_without_text_returns_none(self):
+        self.assertIsNone(
+            convert_claude37_chunk_to_openai({"contentBlockDelta": {"delta": {}}}, "m")
+        )
+
+    def test_parses_json_string_input(self):
+        out = convert_claude37_chunk_to_openai(
+            '{"contentBlockDelta": {"delta": {"text": "x"}}}', "m"
+        )
+        payload = json.loads(out[6:].strip())
+        self.assertEqual(payload["choices"][0]["delta"]["content"], "x")
+
+
+class TestConvertGeminiChunkToOpenAI(unittest.TestCase):
+    def test_text_delta(self):
+        chunk = {"candidates": [{"content": {"parts": [{"text": "hi"}]}}]}
+        out = convert_gemini_chunk_to_openai(chunk, "gemini-2.5-pro")
+        payload = json.loads(out[6:].strip())
+        self.assertEqual(payload["choices"][0]["delta"]["content"], "hi")
+
+    def test_finish_reason(self):
+        chunk = {"candidates": [{"finishReason": "STOP", "content": {"parts": [{"text": "x"}]}}]}
+        payload = json.loads(convert_gemini_chunk_to_openai(chunk, "m")[6:].strip())
+        self.assertEqual(payload["choices"][0]["finish_reason"], "stop")
+
+    def test_no_candidates_returns_none(self):
+        self.assertIsNone(convert_gemini_chunk_to_openai({"candidates": []}, "m"))
+
+
+class TestClaudeDeltaHelpers(unittest.TestCase):
+    def test_gemini_chunk_to_claude_delta(self):
+        chunk = {"candidates": [{"content": {"parts": [{"text": "hi"}]}}]}
+        out = convert_gemini_chunk_to_claude_delta(chunk)
+        self.assertEqual(out["delta"]["text"], "hi")
+        self.assertEqual(out["type"], "content_block_delta")
+
+    def test_gemini_stop_reason(self):
+        chunk = {"candidates": [{"finishReason": "MAX_TOKENS"}]}
+        self.assertEqual(get_claude_stop_reason_from_gemini_chunk(chunk), "max_tokens")
+
+    def test_openai_chunk_to_claude_delta(self):
+        chunk = {"choices": [{"delta": {"content": "hi"}}]}
+        out = convert_openai_chunk_to_claude_delta(chunk)
+        self.assertEqual(out["delta"]["text"], "hi")
+
+    def test_openai_stop_reason(self):
+        chunk = {"choices": [{"finish_reason": "stop"}]}
+        self.assertEqual(get_claude_stop_reason_from_openai_chunk(chunk), "end_turn")
+
+
+# --------------------------------------------------------------------------
+# generate_streaming_response (mocked upstream, real request context)
+# --------------------------------------------------------------------------
+class TestGenerateStreamingResponse(unittest.TestCase):
+    def _run(self, model, fake_response, body=None):
+        body = body or {"model": model, "messages": [{"role": "user", "content": "hi"}]}
+        with app.test_request_context(
+            "/v1/chat/completions", method="POST", json=body
+        ):
+            with patch.object(proxy_server._http_session, "post", return_value=fake_response):
+                with patch.object(proxy_server, "log_token_usage"):
+                    return _drain(
+                        generate_streaming_response(
+                            "https://backend/x", {}, body, model, "SUB"
+                        )
+                    )
+
+    def test_claude_4x_branch_yields_converted_and_done(self):
+        # Claude 3.7/4 branch uses iter_lines and ast.literal_eval on each chunk.
+        lines = [
+            "data: {'contentBlockDelta': {'delta': {'text': 'hi'}}}",
+            "",
+        ]
+        out = self._run("anthropic--claude-4.6-opus", _FakeStreamResponse(lines=lines))
+        self.assertTrue(any('"content": "hi"' in chunk for chunk in out))
+        self.assertEqual(out[-1], "data: [DONE]\n\n")
+
+    def test_gemini_branch_yields_converted_and_done(self):
+        gemini_line = json.dumps({"candidates": [{"content": {"parts": [{"text": "hi"}]}}]})
+        out = self._run("gemini-2.5-pro", _FakeStreamResponse(lines=[f"data: {gemini_line}"]))
+        self.assertTrue(any('"content": "hi"' in chunk for chunk in out))
+        self.assertEqual(out[-1], "data: [DONE]\n\n")
+
+    def test_gpt_branch_passthrough_and_done(self):
+        # Default (GPT) branch uses iter_content and passes bytes through.
+        sse = 'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+        out = self._run("gpt-5.4", _FakeStreamResponse(content_chunks=[sse]))
+        self.assertTrue(any("hi" in chunk for chunk in out))
+        self.assertEqual(out[-1], "data: [DONE]\n\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Relocate all 9 test files from the project root into tests/ to keep the root clean. Add tests/__init__.py and tests/conftest.py (both put the project root on sys.path) plus a small sys.path shim before the proxy_server import in each file, so all invocation styles work:
  - python -m unittest discover -p 'test_*.py'
  - python -m unittest tests.test_x
  - python tests/test_x.py

No test logic changed; all 132 tests pass.